### PR TITLE
include python.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.10)
 project(kincpp)
 
+find_package(Python3 COMPONENTS Development REQUIRED)
+include_directories(${Python3_INCLUDE_DIRS})
+
 set(CMAKE_CXX_FLAGS "-O3 -DNDEBUG -Wno-deprecated-declarations")
 
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)


### PR DESCRIPTION
to be able to build kincpp when python-dev package is installed, but cmake cannot find the Python.h.