### PR TITLE
Fix cmake to allow for non-system python builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,31 +1,44 @@
 cmake_minimum_required(VERSION 3.10)
 project(kincpp)
 
-find_package(Python3 COMPONENTS Development REQUIRED)
-include_directories(${Python3_INCLUDE_DIRS})
+set(CMAKE_CXX_FLAGS "-O3 -DNDEBUG -Wno-deprecated-declarations -fPIC")
+set(CMAKE_CXX_STANDARD 17)
 
-set(CMAKE_CXX_FLAGS "-O3 -DNDEBUG -Wno-deprecated-declarations")
+# Use Python from venv if one is active
+if(DEFINED ENV{VIRTUAL_ENV})
+    set(Python3_EXECUTABLE $ENV{VIRTUAL_ENV}/bin/python)
+    message(STATUS "Using Python from: $ENV{VIRTUAL_ENV}")
+endif()
 
+# Find required packages
 find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
 find_package(pybind11 REQUIRED)
 find_package(Eigen3 REQUIRED)
 
-set(LIBRARY_OUTPUT_PATH "../kincpp")
+set(SOURCES
+    src/kinematics_solver.cpp
+    src/utils.cpp
+)
 
-pybind11_add_module(kincpp
-        src/kinematics_solver.cpp
-        src/utils.cpp)
-
-target_link_libraries(kincpp PRIVATE
-    Eigen3::Eigen)
-
-add_library(kincpp_lib STATIC
-        src/kinematics_solver.cpp
-        src/utils.cpp)
-
-set_target_properties(kincpp_lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
-
+# Static library
+add_library(kincpp_lib STATIC ${SOURCES})
 target_include_directories(kincpp_lib PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_link_libraries(kincpp_lib PUBLIC Eigen3::Eigen)
 
-target_link_libraries(kincpp_lib PRIVATE
-    Eigen3::Eigen)
+# Pybind module
+add_library(kincpp MODULE ${SOURCES})
+target_include_directories(kincpp PRIVATE
+    ${Python3_INCLUDE_DIRS}
+    ${pybind11_INCLUDE_DIRS}
+)
+target_link_libraries(kincpp PRIVATE
+    Eigen3::Eigen
+    pybind11::headers
+)
+
+# Set module properties
+set_target_properties(kincpp PROPERTIES
+    PREFIX ""
+    SUFFIX "${PYTHON_MODULE_EXTENSION}"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/kincpp"
+)


### PR DESCRIPTION
This PR now allows kincpp to build with non-system python versions. It also auto-detects the python version from a venv if activated.

The bug from before was caused by `pybind11_add_module`. It seems that no matter what config is used, `pybind11_add_module` will incorrectly use the system python's ABI instead of the found python. This results in modules that _say_ they are for a certain python version, but when trying to import they are built for the system python.

I've submitted details on this very annoying bug here and will plan on creating a fresh issue to pybind
https://github.com/pybind/pybind11/issues/5100

An accompanying Hobot PR will be submitted.

## Tests

Built `kincpp` on ubuntu 24.04 (system python3.12) using python3.10 venv.
Built `kincpp` on ubuntu 22.04 (system python3.10) using python3.9 venv.

Both can now work without ABI conflicts.