### PR TITLE
Add Python3 header to kincpp_lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,10 @@ set(SOURCES
 
 # Static library
 add_library(kincpp_lib STATIC ${SOURCES})
-target_include_directories(kincpp_lib PUBLIC ${CMAKE_SOURCE_DIR}/src)
+target_include_directories(kincpp_lib PUBLIC
+    ${CMAKE_SOURCE_DIR}/src
+    ${Python3_INCLUDE_DIRS}
+)
 target_link_libraries(kincpp_lib PUBLIC Eigen3::Eigen)
 
 # Pybind module


### PR DESCRIPTION
For some reason PR #5 is enough to build on several desktops but Hobot CICD needs an additional include.

I've tested manually using the Hobot CICD docker that kincpp can now build successfully.